### PR TITLE
added pvc mount to nginx if django pvc

### DIFF
--- a/roles/django_app_k8s/templates/nginx.yml.j2
+++ b/roles/django_app_k8s/templates/nginx.yml.j2
@@ -29,6 +29,11 @@ spec:
         app.kubernetes.io/managed-by: Ansible
     spec:
       volumes:
+{% if django_app_k8s_pvc %}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ django_app_k8s_name_prefix }}-storage
+{% endif %}
         - name: config
           configMap:
             name: {{ django_app_k8s_name_prefix }}-nginx


### PR DESCRIPTION
Nginx deployment (templates/nginx.yml.j2) requires PVC volume if django_app_k8s_pvc or else the mounts will not work and deployment fails. 