### PR TITLE
removed curly bracket too many from nginx config

### DIFF
--- a/roles/django_app_k8s/templates/nginx-config.yml.j2
+++ b/roles/django_app_k8s/templates/nginx-config.yml.j2
@@ -56,7 +56,7 @@ data:
             error_log /var/log/nginx/error.log error;
             return 200 'OK';
         }
-    }
+
 {% for tpl in django_app_k8s_include_templates %}
 {% include tpl %}
 {% endfor %}


### PR DESCRIPTION
Caused nginx fail "location incorrect..." when using custom template (for example adding private-media). 
This should fix it. 