### PR TITLE
variable to define extra pod labels

### DIFF
--- a/roles/django_app_k8s/defaults/main.yml
+++ b/roles/django_app_k8s/defaults/main.yml
@@ -172,3 +172,15 @@ django_app_k8s_pod_security_context:
 django_app_k8s_init_containers: []
 
 django_app_k8s_redis_config_name: redis-config
+
+django_app_k8s_extra_app_labels: []
+
+django_app_k8s_extra_celery_beat_labels: []
+
+django_app_k8s_extra_celery_labels: []
+
+django_app_k8s_extra_flower_labels: []
+
+django_app_k8s_extra_nginx_labels: []
+
+django_app_k8s_extra_redis_labels: []

--- a/roles/django_app_k8s/templates/app.yml.j2
+++ b/roles/django_app_k8s/templates/app.yml.j2
@@ -27,6 +27,10 @@ spec:
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_app_labels %}
+        {{ label }}: {{ django_app_k8s_extra_app_labels[label] }}
+{% endfor %}        
+
     spec:
 
 {% if django_app_k8s_pvc %}

--- a/roles/django_app_k8s/templates/celery-beat.yml.j2
+++ b/roles/django_app_k8s/templates/celery-beat.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: async-workers-cron
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_celery_beat_labels %}
+        {{ label }}: {{ django_app_k8s_extra_celery_beat_labels[label] }}
+{% endfor %}
     spec:
 
 {% if django_app_k8s_pvc %}

--- a/roles/django_app_k8s/templates/celery.yml.j2
+++ b/roles/django_app_k8s/templates/celery.yml.j2
@@ -30,6 +30,9 @@ spec:
         app.kubernetes.io/component: async-workers
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_celery_labels %}
+        {{ label }}: {{ django_app_k8s_extra_celery_labels[label] }}
+{% endfor %}        
     spec:
 
       securityContext: {{ django_app_k8s_pod_security_context }}

--- a/roles/django_app_k8s/templates/flower.yml.j2
+++ b/roles/django_app_k8s/templates/flower.yml.j2
@@ -29,6 +29,9 @@ spec:
         app.kubernetes.io/component: monitoring
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_flower_labels %}
+        {{ label }}: {{ django_app_k8s_extra_flower_labels[label] }}
+{% endfor %}
     spec:
       containers:
       - name: monitoring

--- a/roles/django_app_k8s/templates/nginx.yml.j2
+++ b/roles/django_app_k8s/templates/nginx.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: webserver
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_nginx_labels %}
+        {{ label }}: {{ django_app_k8s_extra_nginx_labels[label] }}
+{% endfor %}
     spec:
       volumes:
 {% if django_app_k8s_pvc %}

--- a/roles/django_app_k8s/templates/redis.yml.j2
+++ b/roles/django_app_k8s/templates/redis.yml.j2
@@ -29,6 +29,10 @@ spec:
         app.kubernetes.io/component: redis
         app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
         app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_redis_labels %}
+        {{ label }}: {{ django_app_k8s_extra_redis_labels[label] }}
+{% endfor %}  
+
     spec:
       containers:
       - name: redis


### PR DESCRIPTION
Added feature to define extra pod labels per component. 

I need to be able to this for Den Haag AKS, where they differentiate between public / non public facing pods using a label. 

Tested on AKS, works. 
