### PR TITLE
docker hostport var fix

### DIFF
--- a/roles/django_app_docker/templates/replicas.yml.j2
+++ b/roles/django_app_docker/templates/replicas.yml.j2
@@ -2,7 +2,7 @@
 {% for n in range(django_app_docker_replicas) %}
 - name: {{ django_app_docker_name_prefix }}-{{ n }}
 {% if _django_app_docker_container_info.results[n].exists %}
-  port: {{ _django_app_docker_container_info.results[n].container.NetworkSettings.Ports['8000/tcp'][0].HostPort }}
+  port: {{ _django_app_docker_container_info.results[n].container.HostConfig.PortBindings['8000/tcp'][0].HostPort }}
 {% else %}
   port: {{ _django_app_docker_freeports.stdout_lines[n] }}
 {% endif %}  

--- a/roles/django_app_nginx/templates/app.conf.j2
+++ b/roles/django_app_nginx/templates/app.conf.j2
@@ -2,7 +2,7 @@
 
 upstream {{ django_app_nginx_prefix }} {
 {% for replica in backend_ports.results %}
-    server 127.0.0.1:{{ replica.container['NetworkSettings']['Ports']['8000/tcp'][0]['HostPort'] }};
+    server 127.0.0.1:{{ replica.container['HostConfig']['PortBindings']['8000/tcp'][0]['HostPort'] }};
 {% endfor %}
 }
 


### PR DESCRIPTION
NetworkSettings.Ports var disappears when the container exists but is not running for what ever reason (restarting / stopped), causing deployment failure.

HostConfig.PortBindings var will work whether the existing container is running or not. 