### PR TITLE
add rabbitmq and more

### DIFF
--- a/roles/django_app_k8s/defaults/main.yml
+++ b/roles/django_app_k8s/defaults/main.yml
@@ -89,6 +89,7 @@ django_app_k8s_storage: 1G
 django_app_k8s_storage_class: ''  # or `azurefile-premium'
 
 django_app_k8s_use_rabbitmq: no
+django_app_k8s_rabbitmq_version: "3.10"
 django_app_k8s_rabbitmq:
   user: "{{ django_app_k8s_name_prefix }}-{{ django_app_k8s_instance }}"
   password: "opennotificaties-{{ django_app_k8s_instance }}"

--- a/roles/django_app_k8s/defaults/main.yml
+++ b/roles/django_app_k8s/defaults/main.yml
@@ -17,20 +17,55 @@ django_app_k8s_extra_dbs: {}
 django_app_k8s_cache_db: 0
 django_app_k8s_extra_caches: []
 
-django_app_k8s_healthcheck_endpoint: /
-django_app_k8s_healthcheck_probe:
+django_app_k8s_readinessprobe_endpoint: /
+django_app_k8s_readinessprobe:
   httpGet:
-    path: "{{ django_app_k8s_healthcheck_endpoint }}"
+    path: "{{ django_app_k8s_readinessprobe_endpoint }}"
     port: 8000
     httpHeaders:
       - name: Host
         value: localhost
   initialDelaySeconds: 30
   periodSeconds: 30
+  timeoutSeconds: 1
+
+django_app_k8s_livenessprobe_endpoint: /
+django_app_k8s_livenessprobe:
+  httpGet:
+    path: "{{ django_app_k8s_livenessprobe_endpoint }}"
+    port: 8000
+    httpHeaders:
+      - name: Host
+        value: localhost
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 1  
 
 django_app_k8s_healthcheck_probes:
-  readiness: "{{ django_app_k8s_healthcheck_probe }}"
-  liveness: "{{ django_app_k8s_healthcheck_probe }}"
+  readiness: "{{ django_app_k8s_readinessprobe }}"
+  liveness: "{{ django_app_k8s_livenessprobe }}"
+
+django_app_k8s_readinessprobe_endpoint_nginx: /
+django_app_k8s_readinessprobe_nginx:
+  httpGet:
+    path: "{{ django_app_k8s_readinessprobe_endpoint_nginx }}"
+    port: 8080
+    httpHeaders:
+      - name: Host
+        value: localhost
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 1
+
+django_app_k8s_livenessprobe_endpoint_nginx: /_health/
+django_app_k8s_livenessprobe_nginx:
+  httpGet:
+    path: "{{ django_app_k8s_livenessprobe_endpoint_nginx }}"
+    port: 8080
+
+django_app_k8s_healthcheck_probes_nginx:
+  readiness: "{{ django_app_k8s_readinessprobe_nginx }}"
+  liveness: "{{ django_app_k8s_livenessprobe_nginx }}"
 
 django_app_k8s_sentry_dsn: null
 
@@ -53,12 +88,21 @@ django_app_k8s_pvc: false
 django_app_k8s_storage: 1G
 django_app_k8s_storage_class: ''  # or `azurefile-premium'
 
+django_app_k8s_use_rabbitmq: no
+django_app_k8s_rabbitmq:
+  user: "{{ django_app_k8s_name_prefix }}-{{ django_app_k8s_instance }}"
+  password: "opennotificaties-{{ django_app_k8s_instance }}"
+  rabbitmq_host: "{{ django_app_k8s_name_prefix }}-rabbitmq"
+  rabbitmq_port: 5672
+
 django_app_k8s_use_celery: no
 django_app_k8s_use_celery_beat: no
 django_app_k8s_celery_replicas: 2
 django_app_k8s_celery_db: 1
 django_app_k8s_celery_broker_url: "redis://{{ django_app_k8s_name_prefix }}-redis:6379/{{ django_app_k8s_celery_db }}"
 django_app_k8s_celery_result_backend: "{{ django_app_k8s_celery_broker_url }}"
+
+
 
 # container stop sends TERM for graceful termination, after this grace period, a KILL
 # is issued. You should set this per worker with the maximum duration of a task (should
@@ -69,6 +113,7 @@ django_app_k8s_celery_workers:
   - queue: celery  # celery is the default queue name
     replicas: "{{ django_app_k8s_celery_replicas }}"  # backwards compatible variables
     grace_time: "{{ django_app_k8s_celery_workers_default_grace_time }}"
+
 
 django_app_k8s_flower_user: flower
 django_app_k8s_flower_password: flower
@@ -100,6 +145,7 @@ django_app_k8s_ingress_annotations:
 #  kubernetes.io/ingress.class: traefik-public
 #  traefik.ingress.kubernetes.io/rule-type: PathPrefixStrip
 django_app_k8s_extra_ingress_paths: []
+django_app_k8s_ingress_classname: nginx
 django_app_k8s_add_nginx: no
 # Custom template snippet to include in nginx config
 django_app_k8s_include_templates: []
@@ -136,6 +182,14 @@ django_app_k8s_flower_resource_limits:
   memory: 500Mi
   cpu: 500m
 
+django_app_k8s_rabbitmq_resource_requests:
+  memory: 300Mi
+  cpu: 100m
+
+django_app_k8s_rabbitmq_resource_limits:
+  memory: 500Mi
+  cpu: 250m
+
 # Example structure:
 #
 # django_app_k8s_cronjobs:
@@ -150,6 +204,8 @@ django_app_k8s_job_annotations:
 
 # Use TLS
 django_app_k8s_use_tls: false
+django_app_k8s_deploy_tls_secret: false
+django_app_k8s_tls_secret_name: "{{django_app_k8s_name_prefix}}-tls"
 # Provide tls secrets when opennotificaties_use_tls is set to true
 django_app_k8s_tls_secrets:
   crt: ''
@@ -191,3 +247,5 @@ django_app_k8s_extra_flower_labels: []
 django_app_k8s_extra_nginx_labels: []
 
 django_app_k8s_extra_redis_labels: []
+
+django_app_k8s_extra_rabbitmq_labels: []

--- a/roles/django_app_k8s/tasks/deployments.yml
+++ b/roles/django_app_k8s/tasks/deployments.yml
@@ -10,6 +10,16 @@
       fail_on_error: yes
       strict: yes
 
+- name: Set up the RabbitMQ deployment
+  k8s:
+    state: present
+    name: "{{ django_app_k8s_name_prefix }}-rabbitmq"
+    namespace: "{{ django_app_k8s_namespace }}"
+    definition: "{{ lookup('template', 'rabbitmq.yml.j2') | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes
+  when: django_app_k8s_use_rabbitmq
 
 - name: Calculate the app container env
   set_fact:

--- a/roles/django_app_k8s/tasks/main.yml
+++ b/roles/django_app_k8s/tasks/main.yml
@@ -11,7 +11,9 @@
   when: django_app_k8s_create_service_account
 
 - import_tasks: tls.yml
-  when: django_app_k8s_use_tls
+  when: 
+    - django_app_k8s_use_tls
+    - django_app_k8s_deploy_tls_secret
 
 - import_tasks: services.yml
 - import_tasks: storage.yml

--- a/roles/django_app_k8s/tasks/services.yml
+++ b/roles/django_app_k8s/tasks/services.yml
@@ -10,6 +10,16 @@
       fail_on_error: yes
       strict: yes
 
+- name: Set up RabbitMQ broker service
+  k8s:
+    state: present
+    name: opennotificaties-rabbitmq
+    namespace: "{{ django_app_k8s_namespace }}"
+    definition: "{{ lookup('template', 'rabbitmq-svc.yml.j2') | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes
+  when: django_app_k8s_use_rabbitmq     
 
 - name: Set up the app service
   k8s:

--- a/roles/django_app_k8s/templates/app-env.yml.j2
+++ b/roles/django_app_k8s/templates/app-env.yml.j2
@@ -85,6 +85,13 @@
       key: CELERY_RESULT_BACKEND
 {% endif %}
 
+{% if django_app_k8s_use_rabbitmq %}
+- name: RABBITMQ_HOST
+  value: "{{ django_app_k8s_rabbitmq.rabbitmq_host | default('app-rabbitmq') }}"
+- name: RABBITMQ_PORT
+  value: "{{ django_app_k8s_rabbitmq.rabbitmq_port | default('5672') }}"
+{% endif %}
+
 {% if django_app_k8s_sentry_dsn %}
 - name: SENTRY_DSN
   valueFrom:

--- a/roles/django_app_k8s/templates/app.yml.j2
+++ b/roles/django_app_k8s/templates/app.yml.j2
@@ -56,8 +56,13 @@ spec:
             memory: {{ django_app_k8s_resource_limits.memory|default('1Gi') }}
             cpu: {{ django_app_k8s_resource_limits.cpu|default('1000m') }}
 
+{% if django_app_k8s_healthcheck_probes.readiness  %}
         readinessProbe: {{ django_app_k8s_healthcheck_probes.readiness }}
+{% endif %}
+
+{% if django_app_k8s_healthcheck_probes.liveness %}        
         livenessProbe: {{ django_app_k8s_healthcheck_probes.liveness }}
+{% endif %}
 
 {% if django_app_k8s_pvc %}
         volumeMounts: {{ django_app_k8s_app_volume_mounts }}

--- a/roles/django_app_k8s/templates/ingress.yml.j2
+++ b/roles/django_app_k8s/templates/ingress.yml.j2
@@ -12,11 +12,12 @@ metadata:
     app.kubernetes.io/managed-by: Ansible
   annotations: {{ django_app_k8s_ingress_annotations }}
 spec:
+  ingressClassName: "{{ django_app_k8s_ingress_classname }}"
 {% if django_app_k8s_use_tls %}
   tls:
     - hosts:
       - "{{ django_app_k8s_domain }}"
-      secretName: "{{ django_app_k8s_name_prefix }}-tls-secrets"
+      secretName: "{{ django_app_k8s_tls_secret_name }}"
 {% endif %}
   rules:
   - host: "{{ django_app_k8s_domain }}"

--- a/roles/django_app_k8s/templates/nginx.yml.j2
+++ b/roles/django_app_k8s/templates/nginx.yml.j2
@@ -52,18 +52,13 @@ spec:
             memory: {{ django_app_k8s_nginx_resource_limits.memory|default('250Mi') }}
             cpu: {{ django_app_k8s_nginx_resource_limits.cpu|default('250m') }}
 
-        readinessProbe:
-          httpGet:
-            port: 8080
-            path: /
-            httpHeaders:
-              - name: Host
-                value: localhost
+{% if django_app_k8s_healthcheck_probes_nginx.readiness %}
+        readinessProbe: {{ django_app_k8s_healthcheck_probes_nginx.readiness }}
+{% endif %}
 
-        livenessProbe:
-          httpGet:
-            port: 8080
-            path: /_health/
+{% if django_app_k8s_healthcheck_probes_nginx.liveness %}
+        livenessProbe: {{ django_app_k8s_healthcheck_probes_nginx.liveness }}
+{% endif %}
 
         volumeMounts:
           - name: config

--- a/roles/django_app_k8s/templates/rabbitmq-svc.yml.j2
+++ b/roles/django_app_k8s/templates/rabbitmq-svc.yml.j2
@@ -1,0 +1,21 @@
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
+    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/component: async-workers
+    app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
+    app.kubernetes.io/managed-by: Ansible
+spec:
+  selector:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
+    app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
+  ports:
+  - protocol: TCP
+    port: 5672
+    targetPort: 5672

--- a/roles/django_app_k8s/templates/rabbitmq-svc.yml.j2
+++ b/roles/django_app_k8s/templates/rabbitmq-svc.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: rabbitmq
     app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "{{ django_app_k8s_rabbitmq_version }}"
     app.kubernetes.io/component: async-workers
     app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
     app.kubernetes.io/managed-by: Ansible

--- a/roles/django_app_k8s/templates/rabbitmq.yml.j2
+++ b/roles/django_app_k8s/templates/rabbitmq.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: rabbitmq
     app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "{{ django_app_k8s_rabbitmq_version }}"
     app.kubernetes.io/component: async-workers
     app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
     app.kubernetes.io/managed-by: Ansible
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq
-        image: rabbitmq:3.7
+        image: rabbitmq:{{ django_app_k8s_rabbitmq_version }}
         imagePullPolicy: Always
 
         resources:

--- a/roles/django_app_k8s/templates/rabbitmq.yml.j2
+++ b/roles/django_app_k8s/templates/rabbitmq.yml.j2
@@ -1,0 +1,69 @@
+---
+
+kind: Deployment
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
+    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/component: async-workers
+    app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
+    app.kubernetes.io/managed-by: Ansible
+spec:
+  # TODO: cluster/HA?
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
+      app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
+  template:
+    metadata:
+      name: opennotificaties-worker
+      labels:
+        app.kubernetes.io/name: rabbitmq
+        app.kubernetes.io/instance: "{{ django_app_k8s_instance }}"
+        app.kubernetes.io/version: "3.7"
+        app.kubernetes.io/component: async-workers
+        app.kubernetes.io/part-of: "{{ django_app_k8s_group }}"
+        app.kubernetes.io/managed-by: Ansible
+{% for label in django_app_k8s_extra_rabbitmq_labels %}
+        {{ label }}: {{ django_app_k8s_extra_rabbitmq_labels[label] }}
+{% endfor %}                
+    spec:
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:3.7
+        imagePullPolicy: Always
+
+        resources:
+          requests: {{ django_app_k8s_rabbitmq_resource_requests }}
+          limits: {{ django_app_k8s_rabbitmq_resource_limits }}
+
+        readinessProbe:
+          tcpSocket:
+            port: 5672
+          initialDelaySeconds: 5
+          periodSeconds: 10
+
+        livenessProbe:
+          tcpSocket:
+            port: 5672
+          initialDelaySeconds: 15
+          periodSeconds: 20
+
+        env:
+          - name: RABBITMQ_DEFAULT_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ django_app_k8s_name_prefix }}-secrets
+                key: RABBITMQ_DEFAULT_USER
+          - name: RABBITMQ_DEFAULT_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ django_app_k8s_name_prefix }}-secrets
+                key: RABBITMQ_DEFAULT_PASS
+
+      serviceAccountName: "{{ django_app_k8s_service_account| default('default') }}"
+      securityContext: {{ django_app_k8s_pod_security_context }}  

--- a/roles/django_app_k8s/templates/secrets.yml.j2
+++ b/roles/django_app_k8s/templates/secrets.yml.j2
@@ -16,6 +16,10 @@ stringData:
 
 {% if django_app_k8s_use_celery %}  FLOWER_BASIC_AUTH: {{ django_app_k8s_flower_basic_auth }}{% endif %}
 
+{% if django_app_k8s_use_rabbitmq %}  RABBITMQ_DEFAULT_USER: {{ django_app_k8s_rabbitmq.user }}{% endif %}
+
+{% if django_app_k8s_use_rabbitmq %}  RABBITMQ_DEFAULT_PASS: {{ django_app_k8s_rabbitmq.password }}{% endif %}
+
 {% for prefix, config in django_app_k8s_extra_dbs.items() %}
   {{ prefix }}_DB_USER: {{ config.username }}
   {{ prefix }}_DB_PASSWORD: {{ config.password }}


### PR DESCRIPTION
- More flexible healthprobes for app and nginx, needed because openforms 403 difficulty;
- Add RabbitMQ deploy, service and vars (required for opennotifications);
- django_app_k8s_ingress_classname [Deprecating the Ingress Class Annotation ](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation);
- More flexible tls-secret, define tls-secret name and skip tls-secret deployment (when secrets are deployed by other methods (eg azure vault or cert-manager letsencrypt);

Tested and works. 