### PR TITLE
add app_database role

### DIFF
--- a/roles/app_database/README.md
+++ b/roles/app_database/README.md
@@ -1,0 +1,82 @@
+App database
+============
+
+Provision the application database.
+
+Requirements
+------------
+
+This role assumes that you have (superuser) access to a PostgreSQL cluster.
+
+Role Variables
+--------------
+
+The following variables are used to connect to the database cluster.
+
+```yaml
+app_db_host: localhost
+app_db_port: 5432
+app_db_login_user: postgres
+app_db_login_password: ""
+app_db_login_db: postgres
+```
+
+There are two flags to control database user and database provisioning:
+
+```yaml
+app_db_provision_user: yes
+app_db_provision_database: yes
+```
+
+Extra database users (e.g. for read-only roles) can be created, example:
+
+```yaml
+app_db_extra_users:
+  - name: johndoe
+    password: secret
+```
+
+Finally, you can configure which extra extensions should be enabled:
+
+```yaml
+app_db_extensions:
+  - pg_trgm
+```
+
+If extra OS-level packages are required, you can specify them with:
+
+```yaml
+app_db_extra_packages:
+  - postgis
+```
+
+Dependencies
+------------
+
+There are no hard dependencies, however this role works well with
+`geerlingguy.postgresql`.
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: db-servers
+  roles:
+    - role: app_database
+      vars:
+        app_db_provision_user: no
+        app_db_provision_database: no
+        app_db_become_user: postgres
+
+        app_db_host: ''
+        app_db_port: "{{ openzaak_db_port }}"
+        app_db_name: "{{ openzaak_db_name }}"
+        app_db_extensions:
+          - postgis
+          - pg_trgm
+```
+
+License
+-------
+
+EUPL-1.2

--- a/roles/app_database/defaults/main.yml
+++ b/roles/app_database/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+
+# Requires the following variables to be externally defined:
+#
+# - app_db_name: name of the application database
+# - app_db_user: username of the application database user
+# - app_db_password: password of the application database user
+#
+# Example usage:
+#
+# - role: app-database
+#   vars:
+#     app_db_name: app
+#     app_db_user: app-user
+#     app_db_password: secret
+
+app_db_host: localhost
+app_db_port: 5432
+app_db_login_user: postgres
+app_db_login_password: ""
+app_db_login_db: "{{ app_db_login_user }}"
+
+app_db_provision_user: yes
+app_db_provision_database: yes
+app_db_become_user: null
+
+app_db_extra_users: []
+# Example:
+#
+# app_db_extra_users:
+#   - name: username
+#     password: password
+#
+
+app_db_extra_packages:
+  - postgis
+
+app_db_extensions: []

--- a/roles/app_database/meta/main.yml
+++ b/roles/app_database/meta/main.yml
@@ -1,0 +1,42 @@
+galaxy_info:
+  author: Maykin Media
+  description: Provision the (PostgreSQL) app database, including the db user
+  company: Maykin Media
+
+  issue_tracker_url: https://github.com/open-zaak/ansible-collection/issues
+
+  license: EUPL-1.2
+
+  min_ansible_version: '2.9'
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  platforms:
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
+        - cosmic
+        - disco
+        - eoan
+
+  galaxy_tags:
+    - postgresql
+    - provision
+    - openzaak
+    - commonground
+
+dependencies: []

--- a/roles/app_database/tasks/main.yml
+++ b/roles/app_database/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+
+# Prepare the database: ensure the database exists and has the required
+# extensions configured + set up a db user.
+
+- name: Set up the database user
+  postgresql_user:
+    state: present
+    name: "{{ app_db_user | mandatory }}"
+    password: "{{ app_db_password | mandatory }}"
+
+    login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
+    port: "{{ app_db_port }}"
+    login_user: "{{ app_db_login_user }}"
+    login_password: "{{ app_db_login_password }}"
+  when: app_db_provision_user
+
+- name: Add application role to superuser
+  postgresql_membership:
+    state: present
+    group: "{{ app_db_user | mandatory }}"
+    target_roles:
+      - "{{ app_db_login_user }}"
+
+    login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
+    port: "{{ app_db_port }}"
+    login_user: "{{ app_db_login_user }}"
+    login_password: "{{ app_db_login_password }}"
+  when: app_db_provision_user and app_db_user != 'postgres'
+
+- name: Set up the extra database users
+  postgresql_user:
+    state: present
+    name: "{{ item.name | mandatory }}"
+    password: "{{ item.password | mandatory }}"
+
+    login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
+    port: "{{ app_db_port }}"
+    login_user: "{{ app_db_login_user }}"
+    login_password: "{{ app_db_login_password }}"
+  with_items: "{{ app_db_extra_users }}"
+  no_log: true
+
+- name: Set up the application database
+  postgresql_db:
+    name: "{{ app_db_name | mandatory }}"
+    owner: "{{ app_db_user | mandatory }}"
+    state: present
+
+    login_host: "{{ app_db_host }}"
+    port: "{{ app_db_port }}"
+    login_user: "{{ app_db_login_user }}"
+    login_password: "{{ app_db_login_password }}"
+  when: app_db_provision_database
+
+- name: Install extra database packages
+  package:
+    name: "{{ app_db_extra_packages }}"
+  when: app_db_extra_packages | bool
+
+- name: Enable the required database extensions
+  postgresql_ext:
+    name: "{{ item }}"
+    db: "{{ app_db_name | mandatory }}"
+    state: present
+
+    login_host: "{{ app_db_host }}"
+    port: "{{ app_db_port }}"
+    login_user: "{{ app_db_login_user }}"
+    login_password: "{{ app_db_login_password }}"
+  become: "{{ app_db_become_user != None }}"
+  become_user: "{{ app_db_become_user }}"
+  # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509
+  vars:
+    ansible_ssh_pipelining: true
+  with_items: "{{ app_db_extensions }}"


### PR DESCRIPTION
Straight from [ansible_collection](https://github.com/open-zaak/ansible-collection/tree/main/roles/app_database)

Because we are now using commonground-ansible (maykinmedia.commonground) collection to deploy openzaak / opennotifications we would like to have this very useful role in maykinmedia.commonground.

