### PR TITLE
Redishelm

### DIFF
--- a/roles/django_app_k8s/README.md
+++ b/roles/django_app_k8s/README.md
@@ -19,6 +19,8 @@ Requirements
 * Access to the K8s cluster and the relevant namespace
 * `kubectl` commandline tool should be installed on your local machine (Ansible control
   node) to validate/debug deployments
+* `helm` commandline tool should be installed on your local machine (Ansible control
+  node) to deploy some components
 * PostgreSQL (or other relevant database engine) must be installed and configured
 
 This role plays well with:

--- a/roles/django_app_k8s/defaults/main.yml
+++ b/roles/django_app_k8s/defaults/main.yml
@@ -169,14 +169,6 @@ django_app_k8s_nginx_resource_limits:
   memory: 500Mi
   cpu: 500m
 
-django_app_k8s_redis_resource_requests:
-  memory: 100Mi
-  cpu: 100m
-
-django_app_k8s_redis_resource_limits:
-  memory: 500Mi
-  cpu: 500m
-
 django_app_k8s_flower_resource_requests:
   memory: 100Mi
   cpu: 100m
@@ -247,9 +239,12 @@ django_app_k8s_extra_flower_labels: []
 
 django_app_k8s_extra_nginx_labels: []
 
-django_app_k8s_extra_redis_labels: []
-
 django_app_k8s_extra_rabbitmq_labels: []
+
+##################
+# Redis chart #
+##################
+# Please consult https://github.com/bitnami/charts/tree/main/bitnami/redis for all posible values
 
 django_app_k8s_redis_helm_values:
   architecture: standalone
@@ -257,8 +252,8 @@ django_app_k8s_redis_helm_values:
     enabled: false
   master:
     persistence:
-      enabled: true
-      size: 1Gi
+      enabled: false
+      size: 8Gi
     resources:
       requests:
         cpu: 10m

--- a/roles/django_app_k8s/defaults/main.yml
+++ b/roles/django_app_k8s/defaults/main.yml
@@ -100,7 +100,7 @@ django_app_k8s_use_celery: no
 django_app_k8s_use_celery_beat: no
 django_app_k8s_celery_replicas: 2
 django_app_k8s_celery_db: 1
-django_app_k8s_celery_broker_url: "redis://{{ django_app_k8s_name_prefix }}-redis:6379/{{ django_app_k8s_celery_db }}"
+django_app_k8s_celery_broker_url: "redis://{{ django_app_k8s_name_prefix }}-redis-master:6379/{{ django_app_k8s_celery_db }}"
 django_app_k8s_celery_result_backend: "{{ django_app_k8s_celery_broker_url }}"
 
 
@@ -237,8 +237,6 @@ django_app_k8s_jobs_security_context: {}
 #
 django_app_k8s_init_containers: []
 
-django_app_k8s_redis_config_name: redis-config
-
 django_app_k8s_extra_app_labels: []
 
 django_app_k8s_extra_celery_beat_labels: []
@@ -252,3 +250,16 @@ django_app_k8s_extra_nginx_labels: []
 django_app_k8s_extra_redis_labels: []
 
 django_app_k8s_extra_rabbitmq_labels: []
+
+django_app_k8s_redis_helm_values:
+  architecture: standalone
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: true
+      size: 1Gi
+    resources:
+      requests:
+        cpu: 10m
+        memory: 20Mi

--- a/roles/django_app_k8s/tasks/config.yml
+++ b/roles/django_app_k8s/tasks/config.yml
@@ -10,13 +10,3 @@
       fail_on_error: yes
       strict: yes
   when: django_app_k8s_add_nginx
-
-- name: Set up redis config
-  k8s:
-    state: present
-    name: "{{ django_app_k8s_redis_config_name }}"
-    namespace: "{{ django_app_k8s_namespace }}"
-    definition: "{{ lookup('template', 'redis-config.yml.j2') | from_yaml }}"
-    validate:
-      fail_on_error: yes
-      strict: yes

--- a/roles/django_app_k8s/tasks/deployments.yml
+++ b/roles/django_app_k8s/tasks/deployments.yml
@@ -1,14 +1,16 @@
 ---
 
-- name: Set up the redis deployment
-  k8s:
-    state: present
+- name: Add bitnami helm repo redis
+  kubernetes.core.helm_repository:
+    name: bitnami
+    repo_url: "https://charts.bitnami.com/bitnami"
+
+- name: Install Redis Helm Chart
+  kubernetes.core.helm:
     name: "{{ django_app_k8s_name_prefix }}-redis"
-    namespace: "{{ django_app_k8s_namespace }}"
-    definition: "{{ lookup('template', 'redis.yml.j2') | from_yaml }}"
-    validate:
-      fail_on_error: yes
-      strict: yes
+    chart_ref: bitnami/redis
+    release_namespace: "{{ django_app_k8s_namespace }}"
+    values: "{{ django_app_k8s_redis_helm_values }}"
 
 - name: Set up the RabbitMQ deployment
   k8s:

--- a/roles/django_app_k8s/tasks/services.yml
+++ b/roles/django_app_k8s/tasks/services.yml
@@ -1,15 +1,4 @@
 ---
-
-- name: Set up the redis service
-  k8s:
-    state: present
-    name: "{{ django_app_k8s_name_prefix }}-redis"
-    namespace: "{{ django_app_k8s_namespace }}"
-    definition: "{{ lookup('template', 'redis-svc.yml.j2') | from_yaml }}"
-    validate:
-      fail_on_error: yes
-      strict: yes
-
 - name: Set up RabbitMQ broker service
   k8s:
     state: present
@@ -30,7 +19,6 @@
     validate:
       fail_on_error: yes
       strict: yes
-
 
 - name: Set up the flower service
   k8s:

--- a/roles/django_app_k8s/templates/app-env.yml.j2
+++ b/roles/django_app_k8s/templates/app-env.yml.j2
@@ -47,13 +47,13 @@
 
 # Caches
 - name: CACHE_DEFAULT
-  value: "{{ django_app_k8s_name_prefix }}-redis:6379/{{ django_app_k8s_cache_db }}"
+  value: "{{ django_app_k8s_name_prefix }}-redis-master:6379/{{ django_app_k8s_cache_db }}"
 - name: CACHE_AXES
-  value: "{{ django_app_k8s_name_prefix }}-redis:6379/{{ django_app_k8s_cache_db }}"
+  value: "{{ django_app_k8s_name_prefix }}-redis-master:6379/{{ django_app_k8s_cache_db }}"
 
 {% for cache in django_app_k8s_extra_caches %}
 - name: CACHE_{{ cache.name }}
-  value: "{{ django_app_k8s_name_prefix }}-redis:6379/{{ cache.db | default(django_app_k8s_cache_db) }}"
+  value: "{{ django_app_k8s_name_prefix }}-redis-master:6379/{{ cache.db | default(django_app_k8s_cache_db) }}"
 {% endfor %}
 
 {% if django_app_k8s_mail %}

--- a/roles/django_app_k8s/templates/redis-config.yml.j2
+++ b/roles/django_app_k8s/templates/redis-config.yml.j2
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-data:
-  redis-config: |
-    save ""


### PR DESCRIPTION
Some components require Redis AOF persistence enabled:

Switched the entire redis deployment to use [Bitnami package for Redis(R)
](https://github.com/bitnami/charts/tree/main/bitnami/redis)

[AOF](https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml#:~:text=%23%23-,commonConfiguration,-%3A%20%7C%2D) is enabled by default. 

Most (if not all) feature requirements (e.g., persistence volumes, existing configmaps, HA requirements, etc) are available in the chart. All values from the chart can be used in the role by setting them in the `django_app_k8s_redis_helm_values` variable.

Deployement was tested on an AKS cluster and works as intended. 


