### PR TITLE
:sparkles: loop_control pause between replicas

### DIFF
--- a/roles/django_app_docker/defaults/main.yml
+++ b/roles/django_app_docker/defaults/main.yml
@@ -80,9 +80,10 @@ django_app_docker_image_always_pull: false
 #                                     #
 #######################################
 
-# Number of desired running web backend containers. Note that all containers are
-# started and stopped together, there are no zero downtime deploys with this setup.
+# Number of desired running web backend containers.
 django_app_docker_replicas: 1
+# Number of seconds to wait between deploying replicas, this can be used to prevent downtime. 
+django_app_docker_replicas_loop_pause: 5
 # Backend ports to expose to NGINX, free ports in this range will be assigned to the host port
 django_app_docker_port_range:
   start: 14000

--- a/roles/django_app_docker/tasks/containers.yml
+++ b/roles/django_app_docker/tasks/containers.yml
@@ -25,6 +25,8 @@
 - name: "Run the django backend containers"
   community.docker.docker_container: "{{ lookup('template', 'django-container.yml.j2') | from_yaml }}"
   loop: "{{ _django_app_docker_replicas }}"
+  loop_control:
+    pause: "{{ django_app_docker_replicas_loop_pause }}"
   register: backend_ports
 
 - name: Determine the celery worker replicas


### PR DESCRIPTION
Currently the loop is "too fast". 

First container is redeployed and is starting to come online, meanwhile ansible will start redeploying the second replica, so there is a short window where both replicas (when using 2 replicas) are down, causing a short dowtime of approximately 30 seconds.

The pause between the items in the loop gives the first container time to come up before the second goes down. 
Tested with 2 replicas, there was no downtime.

Downside is overall deployment will take more time. 

Not sure if there is any use to add it to the celery replicas?
