### PR TITLE
Allow internal only docker network

### DIFF
--- a/roles/django_app_docker/defaults/main.yml
+++ b/roles/django_app_docker/defaults/main.yml
@@ -89,6 +89,9 @@ django_app_docker_port_range:
   start: 14000
   end: 15000
 
+# Set to true to restrict external access to the network
+django_app_docker_network_internal: false 
+
 # Which volumes to create and where to mount them with which mode (rw, ro).
 # Typically created under /var/lib/docker/volumes, ensure you have sufficient disk
 # space.

--- a/roles/django_app_docker/tasks/dependencies.yml
+++ b/roles/django_app_docker/tasks/dependencies.yml
@@ -3,5 +3,6 @@
 # Installs the required dependencies
 
 - name: Install dependencies
-  pip:
-    name: docker
+  ansible.builtin.package:
+    name: python3-docker
+    state: present

--- a/roles/django_app_docker/tasks/network.yml
+++ b/roles/django_app_docker/tasks/network.yml
@@ -3,3 +3,4 @@
 - name: Provision the isolated app container network
   community.docker.docker_network:
     name: "{{ django_app_docker_name_prefix }}"
+    internal: "{{ django_app_docker_network_internal }}"


### PR DESCRIPTION
- Allow to set the docker network to internal, preventing external network access.

- Replace docker pip dependencies with system packages to support Debian 12 installs (works on Debian 11 also);

```
# pip install docker
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

