### PR TITLE
Make celery start command variable

### DIFF
--- a/roles/django_app_docker/defaults/main.yml
+++ b/roles/django_app_docker/defaults/main.yml
@@ -121,6 +121,9 @@ django_app_docker_use_celery: false
 django_app_docker_use_celery_beat: false
 django_app_docker_use_flower: false
 
+# Command to run when starting the celery container, useful if containers are build with e.g. '/celery_start.sh'
+django_app_docker_celery_command: /celery_worker.sh
+
 # Which redis DB to use as broker/result backend
 django_app_docker_celery_db: 1  # uses the same redis instance as cache service
 django_app_docker_broker_url: "redis://{{ django_app_docker_name_prefix }}-redis:6379/{{ django_app_docker_celery_db }}"

--- a/roles/django_app_docker/templates/celery-worker-container.yml.j2
+++ b/roles/django_app_docker/templates/celery-worker-container.yml.j2
@@ -3,7 +3,7 @@
 container_default_behavior: no_defaults
 name: "{{ item.name }}"
 image: "{{ django_app_docker_image | mandatory }}"
-command: ["/celery_worker.sh"]
+command: ["{{ django_app_docker_celery_command }}"]
 hostname: "{{ item.name }}"
 state: started
 pull: yes  # always pull


### PR DESCRIPTION
I'm using docker role to deploy a custom project, but developer called the celery start script `celery_start.sh`. 