### PR TITLE
:bug: Set permissions after container deploy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: maykinmedia
 name: commonground
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.2
+version: 1.1.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/django_app_docker/tasks/main.yml
+++ b/roles/django_app_docker/tasks/main.yml
@@ -6,12 +6,13 @@
 
 # Docker infra provisioning
 - import_tasks: dependencies.yml
-# - import_tasks: docker-login.yml
 - import_tasks: volumes.yml
 - import_tasks: network.yml
 
 - import_tasks: freeports.yml
 - import_tasks: containers.yml
+
+- import_tasks: volumes_permissions.yml
 
 # Cleanup
 - import_tasks: unset_facts.yml

--- a/roles/django_app_docker/tasks/setup_env.yml
+++ b/roles/django_app_docker/tasks/setup_env.yml
@@ -23,5 +23,3 @@
     group: "{{ django_app_docker_app_user }}"
     mode: u=rw,g=r,o=
   register: _django_app_docker_env_file
-
-# TODO: django_app_nginx role which sets up the nginx user access to volumes?

--- a/roles/django_app_docker/tasks/volumes.yml
+++ b/roles/django_app_docker/tasks/volumes.yml
@@ -11,16 +11,3 @@
   register: _django_app_docker_volumes
   notify:
     - print volume mountpoints
-
-# Volumes are created as the root user by the Docker daemon. For containers dropping
-# privileges, the owner must be set appropriately
-- name: Set volume permissions
-  file:
-    path: "{{ item.volume.Mountpoint }}"
-    state: directory
-    owner: "{{ item.item.owner | default(django_app_docker_name_prefix) }}"
-    group: "{{ item.item.group | default(django_app_docker_name_prefix) }}"
-    recurse: "{{ item.item.recurse | default(False) }}"
-    mode: "{{ item.item.perms | default('u=rwx,g=rx,o-rwx') }}"
-  when: item.item.hostPath is not defined or not item.item.hostPath  # only create docker volumes if we're not bind mounting
-  loop: "{{ _django_app_docker_volumes.results }}"

--- a/roles/django_app_docker/tasks/volumes_permissions.yml
+++ b/roles/django_app_docker/tasks/volumes_permissions.yml
@@ -1,0 +1,13 @@
+---
+# Volumes are created as the root user by the Docker daemon. For containers dropping
+# privileges, the owner must be set appropriately
+- name: Set volume permissions
+  ansible.builtin.file:
+    path: "{{ item.volume.Mountpoint }}"
+    state: directory
+    owner: "{{ item.item.owner | default(django_app_docker_app_user) }}"
+    group: "{{ item.item.group | default(django_app_docker_app_user) }}"
+    recurse: "{{ item.item.recurse | default(False) }}"
+    mode: "{{ item.item.perms | default('u=rwx,g=rx,o-rwx') }}"
+  when: item.item.hostPath is not defined or not item.item.hostPath  # only create docker volumes if we're not bind mounting
+  loop: "{{ _django_app_docker_volumes.results }}"


### PR DESCRIPTION
1. Provision docker volumes
2. Set volume permissions
3. Deploy container
4. Docker container set mount point permissions to docker user (group to root default?);

This issue only occurs with first time container deploys, but is very confusing.

So we move step 2 to the end of the role to fix it. 

