### PR TITLE
Fix notify handler reference

### DIFF
--- a/roles/django_app_docker/tasks/volumes.yml
+++ b/roles/django_app_docker/tasks/volumes.yml
@@ -12,4 +12,4 @@
     loop_var: django_app_docker_volume
   register: _django_app_docker_volumes
   notify:
-    - print volume mountpoints
+    - Print volume mountpoints


### PR DESCRIPTION
https://github.com/maykinmedia/ansible-collection/commit/18e93a7bd82b57b99e31823568d3299af6d6e56b broke the relation between handler name and notify reference

Closes #60 