### PR TITLE
:sparkles: [#73] Add `django_app_docker_default_env` dict

### DIFF
--- a/roles/django_app_docker/defaults/main.yml
+++ b/roles/django_app_docker/defaults/main.yml
@@ -243,9 +243,19 @@ django_app_docker_mail_default_from: "{{ django_app_docker_name_prefix }}@{{ dja
 #                                     #
 #######################################
 
-# Add extra arbitrary environment variables. These are added to the end of the .env
-# file, and therefore override any earlier entries.
+# Base environment variables for the Django application.
+# These are added to the end of the .env file, and therefore override any earlier entries.
 #
+# Format:
+#
+#   django_app_docker_default_env:
+#     SOME_ENVVAR: some-value
+#
+django_app_docker_default_env: {}
+
+# Add extra environment variables in addition to the default ones. These are added to the end of the .env
+# file, and therefore override any earlier entries, including those defined in the default environment group.
+
 # Format:
 #
 #   django_app_docker_extra_env:

--- a/roles/django_app_docker/templates/env.j2
+++ b/roles/django_app_docker/templates/env.j2
@@ -63,7 +63,12 @@ JWT_LEEWAY={{ django_app_docker_jwt_leeway }}
 ES_HOST={{ django_app_docker_name_prefix }}-elasticsearch
 {% endif %}
 
-# Extra suplied envvars
+# Default supplied envvars
+{% for name, value in django_app_docker_default_env.items() %}
+{{ name }}={{ value }}
+{% endfor %}
+
+# Extra supplied envvars
 {% for name, value in django_app_docker_extra_env.items() %}
 {{ name }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Fixes #73 and https://github.com/maykinmedia/commonground-deployment/issues/222

Added `django_app_docker_default_env` to define the base environment variables at the `group_vars` level for each project.

`django_app_docker_extra_env` is intended for host-specific environment variables that extend the default configuration for that specific host

Next step are to replace in `commonground-deployment` -> `group_vars`  -> `django_app_docker_extra_env` with `django_app_docker_default_env` and in `host_vars` check the duplicated keys 